### PR TITLE
yhkim13/pgb-5 to develop

### DIFF
--- a/src/pot/event/pot-chat-event.ts
+++ b/src/pot/event/pot-chat-event.ts
@@ -9,9 +9,10 @@ import {
 export type PotChatEventV1Dto = {
   potRoomPk: string;
   userPk: string; // 채팅을 보낸 유저의 ID
+  message: string; // 채팅 메시지
+  timestamp: Date; // 메시지 전송 시간
 };
 
-// TODO
 export class PotChatEventV1 implements PotEvent<PotChatEventV1Dto> {
   private constructor(potPk: string, timestamp: Date, data: PotChatEventV1Dto) {
     this.potRoomPk = potPk;
@@ -40,9 +41,14 @@ export class PotChatEventV1 implements PotEvent<PotChatEventV1Dto> {
       // 채팅을 보낸 유저가 방에 존재하는지 확인
       AssertIfUserInPot(pot, data.userPk);
 
-      // TODO
       // 채팅 이외의 모든 데이터는 건드리지 않아야 합니다.
       // 즉 채팅 이벤트를 제외하고 Pot Event 를 조회하여 Dispatch 하여도 무관하여야 합니다.
+      // 채팅 메시지를 방의 채팅 기록에 추가
+      pot.chatHistory.push({
+        userPk: data.userPk,
+        message: data.message,
+        timestamp: data.timestamp,
+      });
 
       return pot;
     };

--- a/src/pot/model/pot.ts
+++ b/src/pot/model/pot.ts
@@ -1,10 +1,17 @@
 import { PotRoomEntity } from "@src/discovery/model/pot-room.entity";
 
+export type ChatMessage = {
+  userPk: string; // 채팅을 보낸 유저의 ID
+  message: string; // 채팅 메시지
+  timestamp: Date; // 메시지 전송 시간
+};
+
 export class Pot {
   constructor() {
     this.joinedUserPks = [];
     this.accountingRequestedUserPks = [];
     this.accountingConfirmedUserPks = [];
+    this.chatHistory = [];
   }
 
   pk: string;
@@ -30,6 +37,8 @@ export class Pot {
   recipientAmount: number | null; // 송금 받을 금액 (원)
   accountingRequestedUserPks: string[] = []; // 송금 보낼 유저의 ID 리스트
   accountingConfirmedUserPks: string[] = []; // 송금 보낸 유저의 ID 리스트
+
+  chatHistory: ChatMessage[] = [];
 
   public toPotRoomEntity(): PotRoomEntity {
     return {


### PR DESCRIPTION
- feature: pot model 에 chatHistory 추가, potChatEvent 구현 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 채팅 이벤트에 사용자 메시지와 타임스탬프가 함께 기록됩니다.
  - 채팅 기록이 보존되어 이후 대화 흐름을 확인하기가 쉬워졌습니다.
  - 유효한 모임과 참여자를 확인한 뒤에만 채팅이 기록되어 신뢰성이 향상되었습니다.

- 버그 수정
  - 자리표시자 로직을 실제 저장 로직으로 교체하여 기록 누락 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->