### PR TITLE
yhkim13/pbg-26 to develop

### DIFF
--- a/drizzle/schema/popo-chat-msg.ts
+++ b/drizzle/schema/popo-chat-msg.ts
@@ -6,6 +6,7 @@ export const popoChatType = pgEnum("popo_chat_type", [
   "popo-reminder-taxi-call-v1",
   "popo-accounting-reminder-v1",
   "popo-accounting-request-v1",
+  "popo-auto-archive-no-departure-confirm-v1",
 ]);
 
 export const popoActionBtnType = pgEnum("popo_action_btn_type", [

--- a/drizzle/schema/schema.sql
+++ b/drizzle/schema/schema.sql
@@ -125,7 +125,8 @@ CREATE TYPE "popo_chat_type" AS ENUM (
     'popo-departure-confirmed-v1',
     'popo-reminder-taxi-call-v1',
     'popo-accounting-reminder-v1',
-    'popo-accounting-request-v1'
+    'popo-accounting-request-v1',
+    'popo-auto-archive-no-departure-confirm-v1'
 );
 
 CREATE TYPE "popo_action_btn_type" AS ENUM (

--- a/src/database/repository/popo-chat-reservation.repository.ts
+++ b/src/database/repository/popo-chat-reservation.repository.ts
@@ -87,6 +87,16 @@ export class PopoChatReservationRepository {
       );
   }
 
+  /*
+  DELETE FROM popo_chat_reservation
+    WHERE pot_fk = ?1
+   */
+  async deleteByPotFk(potFk: string, tx: TxType): Promise<void> {
+    await tx
+      .delete(popoChatReservation)
+      .where(eq(popoChatReservation.potFk, potFk));
+  }
+
   private resultToPopoChatReservationEntity(
     result: any,
   ): PopoChatReservationEntity {

--- a/src/database/repository/pot-room.repository.ts
+++ b/src/database/repository/pot-room.repository.ts
@@ -112,11 +112,33 @@ export class PotRoomRepository {
     );
   }
 
+  /*
+  UPDATE pot_room
+  SET is_departure_confirmed = true,
+      updated_at = NOW()
+  WHERE pk = ?1;
+   */
   async setDepartureTime(potRoomPk: string, tx: TxType): Promise<void> {
     await tx
       .update(potRoom)
       .set({
         isDepartureConfirmed: true,
+        updatedAt: new Date(),
+      })
+      .where(eq(potRoom.pk, potRoomPk));
+  }
+
+  /*
+  UPDATE pot_room
+  SET is_archived = true,
+      updated_at = NOW()
+  WHERE pk = ?1;
+   */
+  async archivePotRoom(potRoomPk: string, tx: TxType): Promise<void> {
+    await tx
+      .update(potRoom)
+      .set({
+        isArchived: true,
         updatedAt: new Date(),
       })
       .where(eq(potRoom.pk, potRoomPk));

--- a/src/database/repository/user-pot-room.repository.ts
+++ b/src/database/repository/user-pot-room.repository.ts
@@ -51,6 +51,41 @@ export class UserPotRoomRepository {
   }
 
   /*
+  UPDATE user_pot_room
+  SET is_archived = true
+  WHERE pot_room_fk = ?1;
+   */
+  async archiveByPotRoomFk(potRoomFk: string, tx: TxType): Promise<void> {
+    await tx
+      .update(userPotRoom)
+      .set({ isArchived: true })
+      .where(eq(userPotRoom.potRoomFk, potRoomFk));
+  }
+
+  /*
+  UPDATE user_pot_room
+  SET is_host = ?3
+  WHERE pot_room_fk = ?1
+    AND user_fk = ?2;
+   */
+  async updateHostStatus(
+    potRoomFk: string,
+    userFk: string,
+    isHost: boolean,
+    tx: TxType,
+  ): Promise<void> {
+    await tx
+      .update(userPotRoom)
+      .set({ isHost: isHost })
+      .where(
+        and(
+          eq(userPotRoom.potRoomFk, potRoomFk),
+          eq(userPotRoom.userFk, userFk),
+        ),
+      );
+  }
+
+  /*
   SELECT count(*) as count
   FROM user_pot_room
   WHERE pot_room_fk = ?1

--- a/src/popo/popo.service.ts
+++ b/src/popo/popo.service.ts
@@ -1,4 +1,10 @@
-import { forwardRef, Inject, Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleInit,
+} from "@nestjs/common";
 import { PopoChatMsgEntity } from "@src/database/entity/popo-chat-msg.entity";
 import { PopoChatMsgRepository } from "@src/database/repository/popo-chat-msg.repository";
 import { PopoChatReservationRepository } from "@src/database/repository/popo-chat-reservation.repository";

--- a/src/popo/popo.service.ts
+++ b/src/popo/popo.service.ts
@@ -69,6 +69,9 @@ export class PopoService implements OnModuleInit {
           case "popo-accounting-reminder-v1":
             await this.processAccountingReminder(reservation);
             break;
+          case "popo-auto-archive-no-departure-confirm-v1":
+            await this.processAutoArchiveNoDepartureConfirm(reservation);
+            break;
           default:
             // Do nothing for other types
             break;
@@ -148,6 +151,33 @@ export class PopoService implements OnModuleInit {
       pot,
       reservation.formatArguments,
     );
+  }
+
+  private async processAutoArchiveNoDepartureConfirm(
+    reservation: PopoChatReservationEntity,
+  ) {
+    // 출발 시간이 확정된 경우 무시
+    const pot = await this.potService.getPot(reservation.potFk);
+
+    if (pot.departureTime) {
+      // 출발 시간 확정됨 -> 무시
+      return;
+    }
+
+    // 출발 시간이 확정되지 않은 경우 팟 자동 아카이브
+    const autoArchiveNoDepaturePopoChatMsg = this.getPopoChatMsgByType(
+      "popo-auto-archive-no-departure-confirm-v1",
+    );
+
+    this.asyncSendPopoChatMsgToPotRoom(
+      autoArchiveNoDepaturePopoChatMsg,
+      reservation.potFk,
+      pot,
+      reservation.formatArguments,
+    );
+
+    // 팟 아카이브 진행
+    await this.potService.archivePot(pot);
   }
 
   asyncReservePopoChatMsg(

--- a/src/popo/popo.service.ts
+++ b/src/popo/popo.service.ts
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  Inject,
-  Injectable,
-  Logger,
-  OnModuleInit,
-} from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger, OnModuleInit } from "@nestjs/common";
 import { PopoChatMsgEntity } from "@src/database/entity/popo-chat-msg.entity";
 import { PopoChatMsgRepository } from "@src/database/repository/popo-chat-msg.repository";
 import { PopoChatReservationRepository } from "@src/database/repository/popo-chat-reservation.repository";
@@ -159,18 +153,23 @@ export class PopoService implements OnModuleInit {
     // 출발 시간이 확정된 경우 무시
     const pot = await this.potService.getPot(reservation.potFk);
 
+    // 이미 아카이브 된 경우 무시
+    if (pot.isArchived) {
+      return;
+    }
+
     if (pot.departureTime) {
       // 출발 시간 확정됨 -> 무시
       return;
     }
 
     // 출발 시간이 확정되지 않은 경우 팟 자동 아카이브
-    const autoArchiveNoDepaturePopoChatMsg = this.getPopoChatMsgByType(
+    const autoArchiveNoDeparturePopoChatMsg = this.getPopoChatMsgByType(
       "popo-auto-archive-no-departure-confirm-v1",
     );
 
     this.asyncSendPopoChatMsgToPotRoom(
-      autoArchiveNoDepaturePopoChatMsg,
+      autoArchiveNoDeparturePopoChatMsg,
       reservation.potFk,
       pot,
       reservation.formatArguments,
@@ -312,6 +311,12 @@ export class PopoService implements OnModuleInit {
         popoChatMsgType,
         tx,
       );
+    });
+  }
+
+  async deleteAllPopoChatReservation(potPk: string) {
+    await this.dbService.db.transaction(async (tx: TxType) => {
+      await this.popoChatReservationRepository.deleteByPotFk(potPk, tx);
     });
   }
 

--- a/src/pot/event/v1/pot-user-leave-event.ts
+++ b/src/pot/event/v1/pot-user-leave-event.ts
@@ -1,7 +1,5 @@
 import { Pot } from "../../model/pot";
-import { PotArchiveEventV1 } from "./pot-archive-event";
 import type { PotEvent } from "../pot-event";
-import { PotEventReducer } from "../pot-event-reducer";
 import { PotEventStringType } from "../../../../drizzle/schema/pot-event";
 import {
   AssertIfDepartureTimeNotSet,
@@ -45,21 +43,8 @@ export class PotUserLeaveEventV1
       (userId) => userId !== data.userPk,
     );
 
-    // 방에 남은 유저가 없는 경우 방 삭제 TODO
-    if (pot.joinedUserPks.length === 0) {
-      const roomArchiveEvent = PotArchiveEventV1.generatePotArchiveEvent(
-        pot.pk,
-        new Date(),
-        {
-          potRoomPk: pot.pk,
-        },
-      );
-      pot = PotEventReducer.reduce(pot, roomArchiveEvent);
-      return pot;
-    }
-
     // 퇴장한 유저가 방장인 경우 방장 선출
-    if (pot.hostUserPk === data.userPk) {
+    if (pot.hostUserPk === data.userPk && pot.joinedUserPks.length > 0) {
       pot.hostUserPk = pot.joinedUserPks[0];
     }
 

--- a/src/pot/pot.service.ts
+++ b/src/pot/pot.service.ts
@@ -667,6 +667,21 @@ export class PotService {
       await this.userPotRoomRepository.archiveByPotRoomFk(pot.pk, tx);
       await this.potEventRepository.saveEvent(potArchiveEvent, tx);
     });
+
+    this.broadcastingService.asyncBroadcastPotEvent(
+      {
+        pot_pk: pot.pk,
+        timestamp: getUnixTime(potArchiveEvent.timestamp),
+        event_type: potArchiveEvent.eventType,
+        data: potArchiveEvent.toDto(),
+      },
+      pot.joinedUserPks,
+    );
+
+    // 포포 예약 모두 삭제
+    await this.popoService.deleteAllPopoChatReservation(pot.pk);
+
+    return BaseResultDto.OK;
   }
 
   async getPot(potRoomPk: string): Promise<Pot | null> {

--- a/src/pot/pot.service.ts
+++ b/src/pot/pot.service.ts
@@ -39,10 +39,11 @@ import {
   addHours,
   fromUnixTime,
   getUnixTime,
-  subDays,
+  subHours,
   subMinutes,
 } from "date-fns";
 import { PopoService } from "@src/popo/popo.service";
+import { PotArchiveEventV1 } from "@src/pot/event/v1/pot-archive-event";
 
 @Injectable()
 export class PotService {
@@ -92,19 +93,31 @@ export class PotService {
       await this.userPotRoomRepository.insert(userPotRoomEntity, tx);
     });
 
-    const popoChatMsg = this.popoService.getPopoChatMsgByType(
+    const popoDepartureConfirmChatMsg = this.popoService.getPopoChatMsgByType(
       "popo-departure-confirm-request-v1",
     );
 
-    // starts_at 시간 24시간 전 메세지 발송 예약
+    // starts_at 시간 6시간 전 메세지 발송 예약
     this.popoService.asyncReservePopoChatMsg(
-      popoChatMsg,
-      subDays(req.starts_at, 1),
+      popoDepartureConfirmChatMsg,
+      subHours(req.starts_at, 6),
       null,
       pot,
       {
         departureTimeEndsAt: pot.departureAvailableEndTime,
       },
+    );
+
+    // ends_at 시간에 팟 자동 해산 예약
+    const popoAutoArchiveChatMsg = this.popoService.getPopoChatMsgByType(
+      "popo-auto-archive-no-departure-confirm-v1",
+    );
+
+    this.popoService.asyncReservePopoChatMsg(
+      popoAutoArchiveChatMsg,
+      req.ends_at,
+      null,
+      pot,
     );
 
     return {
@@ -339,6 +352,8 @@ export class PotService {
       return BaseResultDto.PotNotExist;
     }
 
+    const previousHostUserPk = pot.hostUserPk;
+
     const potUserLeaveEvent: PotUserLeaveEventV1 =
       PotUserLeaveEventV1.generatePotUserLeaveEvent(potPk, new Date(), {
         potRoomPk: potPk,
@@ -361,6 +376,24 @@ export class PotService {
         userCtx.userId,
         tx,
       );
+      // 방장이 바뀐 경우 user_pot_room 테이블의 is_host 업데이트
+      if (
+        pot.joinedUserPks.length > 0 &&
+        previousHostUserPk !== pot.hostUserPk
+      ) {
+        await this.userPotRoomRepository.updateHostStatus(
+          pot.pk,
+          previousHostUserPk,
+          false,
+          tx,
+        );
+        await this.userPotRoomRepository.updateHostStatus(
+          pot.pk,
+          pot.hostUserPk,
+          true,
+          tx,
+        );
+      }
     });
 
     this.broadcastingService.asyncBroadcastPotEvent(
@@ -373,7 +406,10 @@ export class PotService {
       [...pot.joinedUserPks, userCtx.userId],
     );
 
-    // TODO 모든 참여자가 퇴장했다면 팟 해산 이벤트 전송
+    // 모든 참여자가 퇴장했다면 팟 해산 이벤트 전송
+    if (pot.joinedUserPks.length === 0) {
+      await this.archivePot(pot);
+    }
 
     return BaseResultDto.OK;
   }
@@ -514,6 +550,12 @@ export class PotService {
       pot.pk,
     );
 
+    // 팟 자동 해산 메세지 삭제
+    this.popoService.asyncDeletePopoChatReservation(
+      "popo-auto-archive-no-departure-confirm-v1",
+      pot.pk,
+    );
+
     const taxiCallPopoChatMsg = this.popoService.getPopoChatMsgByType(
       "popo-reminder-taxi-call-v1",
     );
@@ -601,6 +643,30 @@ export class PotService {
     );
 
     return BaseResultDto.OK;
+  }
+
+  async archivePot(pot: Pot): Promise<BaseResultDto> {
+    const now = new Date();
+
+    const potArchiveEvent: PotArchiveEventV1 =
+      PotArchiveEventV1.generatePotArchiveEvent(pot.pk, now, {
+        potRoomPk: pot.pk,
+      });
+
+    try {
+      PotEventReducer.reduce(pot, potArchiveEvent, true);
+    } catch (error) {
+      if (error instanceof PotEventError) {
+        return error.baseResultDto;
+      }
+      throw error;
+    }
+
+    await this.dbService.db.transaction(async (tx: TxType) => {
+      await this.potRoomRepository.archivePotRoom(pot.pk, tx);
+      await this.userPotRoomRepository.archiveByPotRoomFk(pot.pk, tx);
+      await this.potEventRepository.saveEvent(potArchiveEvent, tx);
+    });
   }
 
   async getPot(potRoomPk: string): Promise<Pot | null> {


### PR DESCRIPTION
- feature: 각종 상황에서 팟 해산 처리 및 출발 시간 미등록으로 인한 팟 자동 해산 포포 메세지 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 출발 확인 미응답 시 자동 보관 처리 및 안내 메시지 추가
  * 이벤트 종료 시점 자동 보관 예약 메시지 도입
  * 특정 방 관련 예약·메시지 일괄 삭제 기능 추가

* 변경 사항
  * 출발 알림 발송 시점을 24시간 전에서 6시간 전으로 단축
  * 호스트 변경 시 참가자 호스트 상태 동기화 개선

* 버그 수정
  * 마지막 참가자 이탈 시 방 자동 보관 및 관련 예약/메시지 정리로 잔여 알림 최소화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->