### PR TITLE
yhkim13/pgb-33 to develop

### DIFF
--- a/src/pot/pot.service.ts
+++ b/src/pot/pot.service.ts
@@ -37,6 +37,7 @@ import { PotInfoDto } from "@src/pot/dto/pot.info.dto";
 import { UserRepository } from "@src/database/repository/user.repository";
 import {
   addHours,
+  format,
   fromUnixTime,
   getUnixTime,
   subHours,
@@ -47,6 +48,7 @@ import { PotArchiveEventV1 } from "@src/pot/event/v1/pot-archive-event";
 import { PotOverviewDto } from "@src/pot/dto/pot.overview.dto";
 import { AccountingResultDto } from "@src/accounting/dto/confirm-accounting.dto";
 import { toDateFormatWithTimezone } from "@src/global/utils/convertDate";
+import { ko } from "date-fns/locale";
 
 @Injectable()
 export class PotService {
@@ -108,7 +110,11 @@ export class PotService {
         null,
         pot,
         {
-          departureTimeEndsAt: pot.departureAvailableEndTime,
+          departureTimeEndsAt: format(
+            pot.departureAvailableEndTime,
+            "M월 d일 a h시 m분",
+            { locale: ko },
+          ),
         },
       );
     }
@@ -627,7 +633,11 @@ export class PotService {
       null,
       pot,
       {
-        departureTimeEndsAt: pot.departureAvailableEndTime,
+        departureTimeEndsAt: format(
+          pot.departureAvailableEndTime,
+          "M월 d일 a h시 m분",
+          { locale: ko },
+        ),
       },
     );
 


### PR DESCRIPTION
- feature: 포포 메세지 예약 시 시간 형식 한글로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 출발 가능 종료 시간을 한국어 로케일에 맞춘 사람 친화적 형식으로 표시합니다(예: “M월 d일 a h시 m분”).
  * 앱 내 해당 시간 노출 지점에 동일한 포맷을 일관 적용해 가독성과 이해도를 개선했습니다.
  * 기존 값 표시는 유지하면서 사용자에게는 더 명확한 날짜/시간 표현을 제공합니다.
  * 지역화된 표기로 혼동을 줄이고 예약/일정 확인 과정의 편의성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->