### PR TITLE
yhkim13/pgb-67 to develop

### DIFF
--- a/src/pot/pot.service.ts
+++ b/src/pot/pot.service.ts
@@ -128,6 +128,21 @@ export class PotService {
           ),
         },
       );
+    } else {
+      // 탑승 종료 시간이 6시간 이내로 남은 경우 바로 메세지 발송
+      this.popoService.asyncSendPopoChatMsgToPotRoom(
+        popoDepartureConfirmRequestChatMsg,
+        null,
+        pot,
+        {
+          departureTimeEndsAt: formatInTimeZone(
+            pot.departureAvailableEndTime,
+            "Asia/Seoul",
+            "M월 d일 a h시 m분",
+            { locale: ko },
+          ),
+        },
+      );
     }
 
     // ends_at 시간에 팟 자동 해산 예약


### PR DESCRIPTION
- feat: send message for pot room when departure time is within 6 hours

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 출발 확인 메시지 전송 로직이 개선되었습니다. 출발 예정 시간에 따라 처리 방식이 달라집니다. 6시간 이상 남은 경우 메시지를 예약하며, 6시간 이내인 경우 즉시 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->